### PR TITLE
bump to v1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def package_data(pkg, roots):
 
 setup(
     name='feedback-xblock',
-    version='0.0',
+    version='1.1',
     description='XBlock for providing feedback on course content',
     packages=[
         'feedback',


### PR DESCRIPTION
it was not versioned but we need to bump it to 1.1 instead of 0.1 since we already have the tag for `v1.0` and I don't want to remove it or push-force a tag